### PR TITLE
Include httpx in dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "fastapi",
     "uvicorn",
     "pydantic",
+    "httpx<0.28",
     "pytest",
     "pytest-cov",
 ]


### PR DESCRIPTION
## Summary
- ensure dev extras include `httpx<0.28` so FastAPI test client works

## Testing
- `pip install -e .[dev]`
- `pytest --cov=cab_allocator`

------
https://chatgpt.com/codex/tasks/task_e_6845d7392408832a8678523a8df5e517