### PR TITLE
Add allocation strategy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,36 @@ fare *= surge_multiplier
 ```
 The allocation strategy selects the nearest eligible driver within `max_eta_km`.
 
+### Current Single-Driver Strategy
+The default `SingleStrategy` processes one request at a time:
+1. Compute ride distance and filter out inactive drivers.
+2. Reject Auto/Bike drivers if the category does not match the request.
+3. Verify EVs have enough range for the trip.
+4. Sort remaining drivers by ETA and pick the closest under `max_eta_km`.
+5. Calculate fare based on distance and surge.
+This keeps the algorithm simple and pricing predictable, but a rejected offer
+means the passenger must retry, increasing wait time.
+
+### Alternative Strategies
+#### Batch allocation
+| Pros | Cons |
+| --- | --- |
+| Lower rejection risk and faster acceptance | More network chatter and idle time for drivers who lose the batch |
+| Can reduce passenger ETA | Requires extra logic to track pending offers |
+
+Batching sends the request to several nearby drivers simultaneously. The first
+to accept gets the ride. ETAs usually drop, pricing remains unchanged, and
+drivers may earn less per hour if they frequently miss out while waiting.
+
+#### Multicast for Auto/Bike
+| Pros | Cons |
+| --- | --- |
+| Keeps short-trip ETAs small for low-cost categories | Drivers compete for the same ride, potentially lowering revenue |
+| Encourages quick acceptance | Higher cancellation rates if multiple drivers respond |
+
+Multicasting broadcasts to all autos or bikes within range. Pricing stays the
+same, but heavy competition can push individual driver earnings down.
+
 ## Extending Strategies
 Implement the `AllocationStrategy` interface and register it in the API or service
 layer. Distance providers can be swapped by implementing the `DistanceProvider`


### PR DESCRIPTION
## Summary
- document existing single-driver allocation strategy
- describe batch and multicast approaches in README

## Testing
- `pip install -e .[dev]`
- `pytest --cov=cab_allocator`

------
https://chatgpt.com/codex/tasks/task_e_6845d9f34764832a97e266c17546671e