### PR TITLE
Add category upgrade checking

### DIFF
--- a/cab_allocator/allocation/strategy.py
+++ b/cab_allocator/allocation/strategy.py
@@ -8,6 +8,17 @@ from ..models import Driver, RideRequest, RideEstimate, VehicleCategory
 from ..geo import DistanceProvider
 from ..pricing import FareCalculator
 
+
+def _category_satisfies(driver_cat: VehicleCategory, request_cat: VehicleCategory) -> bool:
+    """Return ``True`` if ``driver_cat`` can serve ``request_cat`` or a higher category."""
+
+    cat = request_cat
+    while cat is not None:
+        if cat == driver_cat:
+            return True
+        cat = cat.upgrade_path()
+    return False
+
 class AllocationStrategy(ABC):
     """Base class for ride allocation strategies."""
 
@@ -55,6 +66,8 @@ class SingleStrategy(AllocationStrategy):
             if not d.is_active(request.timestamp):
                 continue
             if d.category in [VehicleCategory.AUTO, VehicleCategory.BIKE] and d.category != request.category:
+                continue
+            if not _category_satisfies(d.category, request.category):
                 continue
             if d.category == VehicleCategory.EV and d.ev_range_km < ride_distance:
                 continue

--- a/tests/test_allocation.py
+++ b/tests/test_allocation.py
@@ -51,3 +51,15 @@ def test_dynamic_eta_radius():
     night_request = RideRequest(id='rn', pickup=(0, 0), dropoff=(0, 0.1), category=VehicleCategory.MINI, timestamp=time.mktime(time.strptime('23:00', '%H:%M')))
     assert strategy.allocate(day_request, drivers) is None
     assert strategy.allocate(night_request, drivers) is not None
+
+
+def test_upgrade_path():
+    strategy = SingleStrategy(HaversineProvider(), FareCalculator(PricingSettings()))
+
+    sedan_driver = Driver(id='sd', location=(0, 0), category=VehicleCategory.SEDAN, state=DriverState.AVAILABLE)
+    mini_request = RideRequest(id='rm', pickup=(0, 0), dropoff=(0, 0.1), category=VehicleCategory.MINI)
+    assert strategy.allocate(mini_request, [sedan_driver]) is not None
+
+    mini_driver = Driver(id='md', location=(0, 0), category=VehicleCategory.MINI, state=DriverState.AVAILABLE)
+    sedan_request = RideRequest(id='rs', pickup=(0, 0), dropoff=(0, 0.1), category=VehicleCategory.SEDAN)
+    assert strategy.allocate(sedan_request, [mini_driver]) is None


### PR DESCRIPTION
## Summary
- add `_category_satisfies` helper for upgrade checks
- use helper in `SingleStrategy` to skip low category drivers
- test sedan->mini upgrade path

## Testing
- `pytest --cov=cab_allocator`

------
https://chatgpt.com/codex/tasks/task_e_6845e0be4538832abbf32fb354f4848c